### PR TITLE
fix: selection consistency - scrollback guard, cursor overlap, post-copy clear

### DIFF
--- a/crates/app/src/gui_runtime_mouse.rs
+++ b/crates/app/src/gui_runtime_mouse.rs
@@ -84,8 +84,10 @@ impl GuiRuntimeApp {
 
         let mouse_mode = self.terminal.mouse_mode();
 
-        // Selection: left click when mouse mode is off starts text selection.
-        if button_code == 0 && mouse_mode == MouseMode::Off {
+        // Selection: left click when mouse mode is off and live view (not scrollback).
+        // Scrollback view (viewport_offset > 0) uses screen-relative coordinates that
+        // don't map to grid flat-indices, so selection is disabled in that mode.
+        if button_code == 0 && mouse_mode == MouseMode::Off && self.viewport_offset == 0 {
             if is_press {
                 let row = self.mouse_cell_row;
                 let col = self.mouse_cell_col;
@@ -95,6 +97,7 @@ impl GuiRuntimeApp {
                 self.queue_redraw();
             } else if self.selection_anchor.is_some() {
                 self.copy_selection_to_clipboard();
+                self.clear_selection();
             }
             return;
         }

--- a/crates/features/render_cpu/src/rasterize.rs
+++ b/crates/features/render_cpu/src/rasterize.rs
@@ -122,6 +122,13 @@ pub fn render_terminal_buffer(
     // The softbuffer framebuffer persists across frames; clean rows already have
     // correct XOR-inverted pixels from the previous frame. Re-inverting them
     // would toggle the highlight off (XOR is its own inverse).
+    // Skip the cursor cell to avoid double-XOR with the cursor pass below
+    // (two XOR operations cancel out, making the cursor invisible on selection).
+    let cursor_flat = if viewport_offset == 0 && terminal.cursor.visible {
+        (terminal.cursor.row as usize) * grid_cols + terminal.cursor.col as usize
+    } else {
+        usize::MAX
+    };
     if selection_start != u32::MAX {
         let sel_lo = selection_start.min(selection_end) as usize;
         let sel_hi = selection_start.max(selection_end) as usize;
@@ -135,6 +142,9 @@ pub fn render_terminal_buffer(
             let start_col = sel_lo.saturating_sub(row_flat_start);
             let end_col = (sel_hi - row_flat_start).min(grid_cols - 1);
             for col in start_col..=end_col.min(visible_cols - 1) {
+                if row_flat_start + col == cursor_flat {
+                    continue;
+                }
                 draw_cell_invert(
                     buffer,
                     width,

--- a/crates/features/render_gpu/src/terminal.wgsl
+++ b/crates/features/render_gpu/src/terminal.wgsl
@@ -161,8 +161,12 @@ fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
         fg = bg;
     }
 
-    // Selection highlight: invert colors for selected range
-    if grid.selection_start != SEL_NONE {
+    // Selection highlight: invert colors for selected range.
+    // Skip the cursor cell to avoid double-inversion with the cursor pass below
+    // (two swaps cancel out, making the cursor invisible on selected cells).
+    let cursor_index = grid.cursor_row * grid.grid_cols + grid.cursor_col;
+    let is_cursor_cell = grid.cursor_visible != 0u && in.instance == cursor_index;
+    if grid.selection_start != SEL_NONE && !is_cursor_cell {
         let sel_lo = min(grid.selection_start, grid.selection_end);
         let sel_hi = max(grid.selection_start, grid.selection_end);
         if in.instance >= sel_lo && in.instance <= sel_hi {
@@ -175,8 +179,7 @@ fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
     // Cursor: shape-aware rendering (DECSCUSR)
     // Shapes: 0/1=blinking block, 2=steady block, 3=blinking underline,
     // 4=steady underline, 5=blinking bar, 6=steady bar.
-    let cursor_index = grid.cursor_row * grid.grid_cols + grid.cursor_col;
-    if grid.cursor_visible != 0u && in.instance == cursor_index {
+    if is_cursor_cell {
         let shape = grid.cursor_shape;
         let is_blinking = (shape == 0u || (shape & 1u) != 0u);
         let cursor_on = !is_blinking || grid.blink_visible != 0u;


### PR DESCRIPTION
## Summary

Three selection bugs found by deep code review agents (better-explorer + better-code-review):

- **Scrollback guard**: Disable text selection when `viewport_offset > 0` (scrollback view). Screen-relative mouse coordinates don't map to grid flat-indices in scrollback mode, producing wrong highlights and clipboard copy from incorrect rows. Matches xterm/alacritty/kitty behavior.

- **Cursor-on-selection double-inversion**: Skip cursor cell in selection XOR/swap pass to prevent two inversions canceling each other out (`XOR(XOR(x)) = x`), which made the cursor invisible when it sat on a selected cell. Fixed in both CPU (`rasterize.rs`) and GPU (`terminal.wgsl`) paths.

- **Post-copy clear**: Call `clear_selection()` after `copy_selection_to_clipboard()` on mouse release to remove stale highlight from the framebuffer. Previously the highlight persisted until the next keypress.

## Test plan

- [ ] CPU mode: select text, verify cursor remains visible on selected cell
- [ ] GPU mode: select text, verify cursor remains visible on selected cell
- [ ] Release mouse after selection: highlight clears immediately
- [ ] Scroll back with Shift+PageUp, left-click: no selection starts
- [ ] `cargo test --workspace` passes (566 tests)
- [ ] `cargo clippy --workspace -- -D warnings` clean