### PR TITLE
fix(core): correct DECSTBM underflow, scrollback false-positive events, dead code

### DIFF
--- a/crates/core/src/parser/csi.rs
+++ b/crates/core/src/parser/csi.rs
@@ -101,7 +101,11 @@ impl Parser {
             b'r' => {
                 let top = position_param(&parsed, 0);
                 let bottom = if parsed.len() >= 2 {
-                    parsed.get(1).flatten().map(|value| value - 1)
+                    parsed
+                        .get(1)
+                        .flatten()
+                        .filter(|&value| value > 0)
+                        .map(|value| value.saturating_sub(1))
                 } else {
                     None
                 };

--- a/crates/core/src/scrollback.rs
+++ b/crates/core/src/scrollback.rs
@@ -58,7 +58,7 @@ impl Scrollback {
 
     pub fn push(&mut self, mut line: String) -> usize {
         if self.cap == 0 || self.byte_cap == 0 {
-            return 1;
+            return 0;
         }
 
         // Keep logical text while dropping right-side padding cells to reduce RAM.
@@ -70,7 +70,7 @@ impl Scrollback {
         }
 
         if line.len() > self.byte_cap {
-            return 1;
+            return 0;
         }
 
         self.byte_len = self.byte_len.saturating_add(line.len());
@@ -89,7 +89,7 @@ impl Scrollback {
     /// `row_string` allocation in the scroll hot path.
     pub fn push_from_cells(&mut self, cells: &[Cell]) -> usize {
         if self.cap == 0 || self.byte_cap == 0 {
-            return 1;
+            return 0;
         }
 
         let mut line = String::with_capacity(cells.len());
@@ -133,8 +133,8 @@ mod tests {
     fn cap_zero_discards_every_line() {
         let mut scrollback = Scrollback::new(0);
 
-        assert_eq!(scrollback.push("l1".to_string()), 1);
-        assert_eq!(scrollback.push("l2".to_string()), 1);
+        assert_eq!(scrollback.push("l1".to_string()), 0);
+        assert_eq!(scrollback.push("l2".to_string()), 0);
         assert!(scrollback.is_empty());
     }
 
@@ -168,7 +168,7 @@ mod tests {
     #[test]
     fn oversized_line_is_dropped_when_it_exceeds_byte_budget() {
         let mut scrollback = Scrollback::with_byte_cap(10, 3);
-        assert_eq!(scrollback.push("🚀".to_string()), 1);
+        assert_eq!(scrollback.push("🚀".to_string()), 0);
         assert!(scrollback.is_empty());
         assert_eq!(scrollback.byte_len(), 0);
     }
@@ -178,7 +178,7 @@ mod tests {
         let mut scrollback = Scrollback::with_byte_cap(10, 6);
         assert_eq!(scrollback.push("ab".to_string()), 0);
         assert_eq!(scrollback.push("cd".to_string()), 0);
-        assert_eq!(scrollback.push("toolong".to_string()), 1);
+        assert_eq!(scrollback.push("toolong".to_string()), 0);
 
         assert_eq!(scrollback.len(), 2);
         assert_eq!(scrollback.get(0), Some("ab"));

--- a/crates/core/src/state/actions.rs
+++ b/crates/core/src/state/actions.rs
@@ -411,12 +411,8 @@ impl TerminalState {
             self.scroll_region = Some((top, bottom));
         }
         // CSI r also homes the cursor
-        let from = self.cursor;
         self.cursor.row = 0;
         self.cursor.col = 0;
-        if from != self.cursor {
-            // no event needed for implicit home from CSI r
-        }
     }
 
     pub(super) fn apply_insert_lines(&mut self, n: u16) {

--- a/crates/core/src/state/tests_modes.rs
+++ b/crates/core/src/state/tests_modes.rs
@@ -926,3 +926,16 @@ fn decscusr_sets_cursor_shape() {
     let _ = state.feed(b"\x1b[0 q");
     assert_eq!(state.cursor_shape(), 0);
 }
+
+#[test]
+fn decstbm_zero_bottom_does_not_underflow() {
+    // CSI 0;0r sends both params as 0. The bottom param (0) must not underflow
+    // when converted from 1-based to 0-based via subtraction.
+    let mut state = TerminalState::new(10, 5, 5);
+    let _ = state.feed(b"\x1b[0;0r");
+    // With both params defaulting, scroll_region should be cleared (full screen)
+    assert_eq!(state.scroll_region, None);
+    // Cursor must be homed
+    assert_eq!(state.cursor.row, 0);
+    assert_eq!(state.cursor.col, 0);
+}


### PR DESCRIPTION
## Summary

- **R-001 HIGH**: DECSTBM (`CSI r`) bottom param 0 treated as default (last row) per VT spec, preventing `u16` underflow when `CSI 0;0r` is sent
- **R-002 MEDIUM**: `Scrollback::push`/`push_from_cells` return 0 when cap is disabled or line exceeds byte budget (no lines evicted = no false `ScrollbackTrimmed` events)
- **R-008 LOW**: Remove dead code in `apply_set_scroll_region` (unused variable + empty conditional)
- **R-009 LOW**: Add regression test for `CSI 0;0r` malformed parameter

## Test plan
- [x] `cargo check --workspace` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo test --workspace` passes (567 tests, 0 failures)
- [x] `cargo fmt --all -- --check` passes
- [x] New test `decstbm_zero_bottom_does_not_underflow` verifies the fix
- [x] Updated scrollback tests verify correct return value semantics