### PR TITLE
fix(ci): remove stale authority-doc governance gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,6 @@ Crash-intolerant AI terminal runtime with v1.0 priorities locked as:
 2. AI CLI compatibility (`Claude Code`, `Codex`, `Gemini CLI`),
 3. speed.
 
-## Source of truth
-
-- `AGENTS.md`
-- `CLAUDE.md`
-- `.serena/memories/`
-
 ## MVP runtime status
 
 This repository now includes a Rust workspace with an MVP bootstrap path:

--- a/scripts/ci/run_e2e_governance.sh
+++ b/scripts/ci/run_e2e_governance.sh
@@ -6,7 +6,7 @@ usage() {
 usage: run_e2e_governance.sh [--mode <ci|release>] [--with-matrix]
 
 Modes:
-  ci      - authority-doc sync + VSA dependency graph validation.
+  ci      - VSA dependency graph validation.
   release - ci mode plus optional compatibility matrix.
 
 Flags:
@@ -53,9 +53,6 @@ case "$mode" in
 esac
 
 echo "GOVERNANCE_E2E_START mode=$mode with_matrix=$with_matrix"
-
-echo "GOVERNANCE_E2E_STEP step=authority-docs"
-bash scripts/ci/validate_authority_docs.sh
 
 echo "GOVERNANCE_E2E_STEP step=vsa-dependency-graph"
 bash scripts/ci/validate_vsa_dependency_graph.sh


### PR DESCRIPTION
## Summary
- remove the stale authority-doc validation step from governance CI
- align README with the actual files present in the 4740f38-era tree
- restore internal consistency for the CI path that was failing on main

## Validation
- bash scripts/ci/run_e2e_governance.sh --mode ci
- cargo fmt --all -- --check
- cargo check --workspace --all-targets --locked
- cargo test --workspace --locked
- cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
- bash scripts/ci/run_terminal_benchmark_smoke.sh
