### PR TITLE
fix(ci): restore benchmark coverage completeness gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,7 +164,7 @@ jobs:
           sudo apt-get -o Acquire::Retries=3 update
           sudo apt-get -o Acquire::Retries=3 install -y --no-install-recommends libxkbcommon-dev libwayland-dev
       - name: Benchmark helper unit tests
-        run: python3 -m unittest scripts.ci.test_terminal_benchmark_environment
+        run: python3 -m unittest scripts.ci.test_terminal_benchmark_environment scripts.ci.test_validate_terminal_benchmark_report
       - run: bash scripts/ci/run_terminal_benchmark_smoke.sh
 
   fmt:

--- a/scripts/ci/terminal_benchmark_manifest.py
+++ b/scripts/ci/terminal_benchmark_manifest.py
@@ -3,6 +3,15 @@ from __future__ import annotations
 
 from typing import Any
 
+EXPECTED_HEADLESS_VERIFIED_ONLY_LAYERS = frozenset(
+    {
+        "app",
+        "foundation",
+        "foundation-platform",
+        "features/diagnostics",
+    }
+)
+
 
 def require_suite_manifest(payload: dict[str, Any]) -> dict[str, dict[str, Any]]:
     manifest = payload.get("suite_manifest")
@@ -45,6 +54,26 @@ def require_suite_manifest(payload: dict[str, Any]) -> dict[str, dict[str, Any]]
 
 def require_suite_manifest_names(payload: dict[str, Any]) -> set[str]:
     return set(require_suite_manifest(payload))
+
+
+def headless_benchmarked_layer_scenarios(payload: dict[str, Any]) -> dict[str, set[str]]:
+    if payload.get("suite") != "canonical-headless":
+        raise ValueError("headless coverage helpers require canonical-headless suite")
+
+    layers: dict[str, set[str]] = {}
+    for scenario, entry in require_suite_manifest(payload).items():
+        layers.setdefault(entry["layer"], set()).add(scenario)
+    return layers
+
+
+def headless_verified_only_layer_scenarios(payload: dict[str, Any]) -> dict[str, set[str]]:
+    if payload.get("suite") != "canonical-headless":
+        raise ValueError("headless coverage helpers require canonical-headless suite")
+
+    return {
+        layer: set()
+        for layer in EXPECTED_HEADLESS_VERIFIED_ONLY_LAYERS
+    }
 
 
 def controlled_display_cpu_scenarios(payload: dict[str, Any]) -> set[str]:

--- a/scripts/ci/test_validate_terminal_benchmark_report.py
+++ b/scripts/ci/test_validate_terminal_benchmark_report.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import pathlib
+import tempfile
+import unittest
+from unittest import mock
+
+try:
+    from scripts.ci import validate_terminal_benchmark_report
+except ModuleNotFoundError:
+    import validate_terminal_benchmark_report
+
+
+class ValidateTerminalBenchmarkReportTests(unittest.TestCase):
+    def test_valid_full_suite_report_passes(self) -> None:
+        self.assertEqual(self._run_validator(make_headless_report()), 0)
+
+    def test_missing_benchmarked_layer_fails(self) -> None:
+        payload = make_headless_report()
+        payload["coverage"]["benchmarked_layers"] = payload["coverage"]["benchmarked_layers"][:-1]
+
+        with self.assertRaises(SystemExit) as exc:
+            self._run_validator(payload)
+
+        self.assertIn("coverage.benchmarked_layers mismatch", str(exc.exception))
+
+    def test_empty_coverage_lists_fail(self) -> None:
+        payload = make_headless_report()
+        payload["coverage"]["benchmarked_layers"] = []
+        payload["coverage"]["verified_only_layers"] = []
+
+        with self.assertRaises(SystemExit) as exc:
+            self._run_validator(payload)
+
+        self.assertIn("coverage.benchmarked_layers mismatch", str(exc.exception))
+
+    def test_benchmarked_layer_scenarios_must_match_manifest(self) -> None:
+        payload = make_headless_report()
+        payload["coverage"]["benchmarked_layers"][0]["benchmark_scenarios"] = []
+
+        with self.assertRaises(SystemExit) as exc:
+            self._run_validator(payload)
+
+        self.assertIn("benchmark_scenarios mismatch", str(exc.exception))
+
+    def _run_validator(self, payload: dict) -> int:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            report_path = pathlib.Path(temp_dir) / "report.json"
+            report_path.write_text(json.dumps(payload), encoding="utf-8")
+            argv = [
+                "validate_terminal_benchmark_report.py",
+                str(report_path),
+                "--require-full-suite",
+            ]
+            with mock.patch("sys.argv", argv):
+                return validate_terminal_benchmark_report.main()
+
+
+def make_headless_report() -> dict:
+    scenarios = [
+        {
+            "scenario": "core-ingest-burst",
+            "layer": "core",
+            "benchmark_kind": "throughput",
+            "description": "core ingest burst",
+            "primary_unit_label": "bytes",
+        },
+        {
+            "scenario": "ui-command-cycle",
+            "layer": "ui",
+            "benchmark_kind": "control-plane",
+            "description": "ui command cycle",
+            "primary_unit_label": "commands",
+        },
+        {
+            "scenario": "cpu-render-full",
+            "layer": "features/render-cpu",
+            "benchmark_kind": "raster",
+            "description": "cpu render full",
+            "primary_unit_label": "frames",
+        },
+    ]
+    scenario_names = [entry["scenario"] for entry in scenarios]
+    return {
+        "benchmark_tool": "terminal-benchmark",
+        "suite": "canonical-headless",
+        "suite_manifest": {
+            "schema_version": 1,
+            "scenarios": [
+                {
+                    **entry,
+                    "backend": None,
+                    "controlled_monitor_cadence": False,
+                }
+                for entry in scenarios
+            ],
+        },
+        "selected_scenarios": scenario_names,
+        "results": [
+            {
+                **entry,
+                "stats": {},
+                "notes": [],
+            }
+            for entry in scenarios
+        ],
+        "coverage": {
+            "benchmarked_layers": [
+                coverage_layer(
+                    "core",
+                    ["core-ingest-burst"],
+                    ["cargo test -p rldyourterm-core --locked"],
+                    "core coverage",
+                ),
+                coverage_layer(
+                    "ui",
+                    ["ui-command-cycle"],
+                    ["cargo test -p rldyourterm-ui --locked"],
+                    "ui coverage",
+                ),
+                coverage_layer(
+                    "features/render-cpu",
+                    ["cpu-render-full"],
+                    ["cargo test -p rldyourterm-render-cpu --locked"],
+                    "cpu render coverage",
+                ),
+            ],
+            "verified_only_layers": [
+                coverage_layer("app", [], ["cargo test -p rldyourterm-app --locked"], "app coverage"),
+                coverage_layer(
+                    "foundation",
+                    [],
+                    ["cargo test -p rldyourterm-foundation --locked"],
+                    "foundation coverage",
+                ),
+                coverage_layer(
+                    "foundation-platform",
+                    [],
+                    ["cargo test -p rldyourterm-foundation-platform --locked"],
+                    "foundation platform coverage",
+                ),
+                coverage_layer(
+                    "features/diagnostics",
+                    [],
+                    ["cargo test -p rldyourterm-diagnostics --locked"],
+                    "diagnostics coverage",
+                ),
+            ],
+        },
+        "workload": {
+            "ai_burst_bytes": 1,
+            "scrollback_flood_bytes": 1,
+            "render_seed_bytes": 1,
+            "delta_batches": 1,
+            "session_cycles": 1,
+            "ui_batch_repetitions": 1,
+            "settings_rounds": 1,
+            "shell_rounds": 1,
+            "font_passes": 1,
+            "surface_rounds": 1,
+        },
+    }
+
+
+def coverage_layer(
+    layer: str,
+    benchmark_scenarios: list[str],
+    validation_commands: list[str],
+    notes: str,
+) -> dict:
+    return {
+        "layer": layer,
+        "benchmark_scenarios": benchmark_scenarios,
+        "validation_commands": validation_commands,
+        "notes": notes,
+    }
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/ci/validate_terminal_benchmark_report.py
+++ b/scripts/ci/validate_terminal_benchmark_report.py
@@ -5,9 +5,17 @@ import pathlib
 import sys
 
 try:
-    from scripts.ci.terminal_benchmark_manifest import require_suite_manifest
+    from scripts.ci.terminal_benchmark_manifest import (
+        headless_benchmarked_layer_scenarios,
+        headless_verified_only_layer_scenarios,
+        require_suite_manifest,
+    )
 except ModuleNotFoundError:
-    from terminal_benchmark_manifest import require_suite_manifest
+    from terminal_benchmark_manifest import (
+        headless_benchmarked_layer_scenarios,
+        headless_verified_only_layer_scenarios,
+        require_suite_manifest,
+    )
 
 EXPECTED_TOOL = "terminal-benchmark"
 EXPECTED_SUITE = "canonical-headless"
@@ -24,20 +32,28 @@ def require_list(payload: dict, key: str) -> list:
     return value
 
 
-def validate_coverage_layers(entries: list, manifest_names: set[str], label: str) -> None:
-    actual_layers = set()
+def validate_coverage_layers(
+    entries: list,
+    expected_layer_scenarios: dict[str, set[str]],
+    manifest_names: set[str],
+    label: str,
+) -> None:
+    actual_layer_scenarios: dict[str, set[str]] = {}
     for entry in entries:
         if not isinstance(entry, dict):
             fail(f"coverage.{label} entries must be objects")
         layer = entry.get("layer")
         if not isinstance(layer, str) or not layer:
             fail(f"coverage.{label}.layer must be a non-empty string")
-        actual_layers.add(layer)
+        if layer in actual_layer_scenarios:
+            fail(f"coverage.{label} must not contain duplicate layers")
         benchmark_scenarios = entry.get("benchmark_scenarios")
         validation_commands = entry.get("validation_commands")
         notes = entry.get("notes")
         if not isinstance(benchmark_scenarios, list):
             fail(f"coverage entry {layer} benchmark_scenarios must be a list")
+        if len(benchmark_scenarios) != len(set(benchmark_scenarios)):
+            fail(f"coverage entry {layer} benchmark_scenarios must be unique")
         for scenario in benchmark_scenarios:
             if not isinstance(scenario, str) or not scenario:
                 fail(f"coverage entry {layer} benchmark_scenarios must contain non-empty strings")
@@ -47,8 +63,22 @@ def validate_coverage_layers(entries: list, manifest_names: set[str], label: str
             fail(f"coverage entry {layer} validation_commands must be a non-empty list")
         if not isinstance(notes, str) or not notes:
             fail(f"coverage entry {layer} notes must be a non-empty string")
-    if len(actual_layers) != len(entries):
-        fail(f"coverage.{label} must not contain duplicate layers")
+        actual_layer_scenarios[layer] = set(benchmark_scenarios)
+
+    expected_layers = set(expected_layer_scenarios)
+    actual_layers = set(actual_layer_scenarios)
+    if actual_layers != expected_layers:
+        fail(
+            f"coverage.{label} mismatch: expected {sorted(expected_layers)}, got {sorted(actual_layers)}"
+        )
+
+    for layer, expected_scenarios in expected_layer_scenarios.items():
+        actual_scenarios = actual_layer_scenarios[layer]
+        if actual_scenarios != expected_scenarios:
+            fail(
+                f"coverage entry {layer} benchmark_scenarios mismatch: "
+                f"expected {sorted(expected_scenarios)}, got {sorted(actual_scenarios)}"
+            )
 
 
 def main() -> int:
@@ -130,13 +160,20 @@ def main() -> int:
     if not isinstance(coverage, dict):
         fail("coverage must be an object")
     manifest_names = set(manifest_map)
+    try:
+        expected_benchmarked_layers = headless_benchmarked_layer_scenarios(payload)
+        expected_verified_only_layers = headless_verified_only_layer_scenarios(payload)
+    except ValueError as exc:
+        fail(str(exc))
     validate_coverage_layers(
         require_list(coverage, "benchmarked_layers"),
+        expected_benchmarked_layers,
         manifest_names,
         "benchmarked_layers",
     )
     validate_coverage_layers(
         require_list(coverage, "verified_only_layers"),
+        expected_verified_only_layers,
         manifest_names,
         "verified_only_layers",
     )


### PR DESCRIPTION
## Summary
- restore full coverage layer completeness checks in `validate_terminal_benchmark_report.py`
- derive expected benchmarked layers from `suite_manifest` and keep explicit governance policy only for verified-only layers
- add regression tests that fail when coverage layer metadata is dropped or emptied
- run the new validator tests in CI benchmark helper unit tests

## Why
The previous refactor removed the exact layer-set check for coverage metadata. That allowed `--require-full-suite` benchmark validation to pass even when benchmarked or verified-only coverage entries were missing or empty.

## Validation
- `python3 -m unittest scripts.ci.test_terminal_benchmark_environment scripts.ci.test_validate_terminal_benchmark_report`
- `bash scripts/ci/run_terminal_benchmark_smoke.sh`