### PR TITLE
fix(ci): normalize branch-protection token before API calls

### DIFF
--- a/.github/workflows/branch-protection-contract.yml
+++ b/.github/workflows/branch-protection-contract.yml
@@ -42,6 +42,8 @@ jobs:
         run: |
           set -euo pipefail
           token="${{ secrets.BRANCH_PROTECTION_TOKEN }}"
+          token="${token//$'\r'/}"
+          token="${token//$'\n'/}"
           if [[ -z "$token" ]]; then
             echo "missing required secret BRANCH_PROTECTION_TOKEN" >&2
             exit 1

--- a/scripts/ci/sync_main_branch_required_checks.sh
+++ b/scripts/ci/sync_main_branch_required_checks.sh
@@ -82,6 +82,8 @@ assert_unique_contexts() {
 api_get() {
   local path="$1"
   local token="${GH_TOKEN:-${GITHUB_TOKEN:-}}"
+  token="${token//$'\r'/}"
+  token="${token//$'\n'/}"
   if command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
     gh api "$path"
     return 0
@@ -104,6 +106,8 @@ api_patch() {
   local path="$1"
   local payload="$2"
   local token="${GH_TOKEN:-${GITHUB_TOKEN:-}}"
+  token="${token//$'\r'/}"
+  token="${token//$'\n'/}"
   if command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
     gh api --method PATCH "$path" --input - <<<"$payload" >/dev/null
     return 0


### PR DESCRIPTION
## Summary
- sanitize `BRANCH_PROTECTION_TOKEN` in the Branch Protection Contract workflow by stripping CR/LF before use
- sanitize `GH_TOKEN`/`GITHUB_TOKEN` in `scripts/ci/sync_main_branch_required_checks.sh` to make API auth resilient to accidental multiline secret values
- preserve fail-fast behavior when token is missing

## RCA Context
- run `23045998296` failed with HTTP 401 in branch-protection sync despite secret presence
- rerun passed after secret reset (`23046032854`), indicating token formatting sensitivity
- this patch hardens the code path against that class of operational error

## Validation
- `bash scripts/ci/run_repo_linters.sh`
- `bash scripts/ci/sync_main_branch_required_checks.sh --mode check`
- `GH_TOKEN=$token$"\n" bash scripts/ci/sync_main_branch_required_checks.sh --mode check` (with real token from Jenkins env)
