### PR TITLE
perf(font): eliminate third hash lookup on GlyphCache miss path

### DIFF
--- a/crates/features/font/src/lib.rs
+++ b/crates/features/font/src/lib.rs
@@ -146,7 +146,7 @@ impl GlyphCache {
             if ch != FALLBACK_GLYPH_CHAR {
                 self.eviction_queue.push_back(ch);
             }
-            self.cache.entry(ch).or_insert(bitmap);
+            return self.cache.entry(ch).or_insert(bitmap);
         }
 
         self.cache


### PR DESCRIPTION
## Summary
- `GlyphCache::get()` miss path performed 3 hash lookups: `contains_key` + `entry().or_insert()` + `get()`
- The `entry().or_insert()` return value was discarded, forcing a redundant `get(&ch)` after insertion
- Fix: return directly from `entry()` on the miss path, reducing lookups from 3 to 2

Found during final consistency audit after RCA session.

## Test plan
- [x] 761 tests pass, 0 clippy warnings