### PR TITLE
ci: add merge_group trigger to cflite_pr and version comment to router Dockerfile

### DIFF
--- a/.github/workflows/cflite_pr.yml
+++ b/.github/workflows/cflite_pr.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     branches: [main]
     types: [opened, reopened, synchronize, ready_for_review]
+  merge_group:
+    types: [checks_requested]
   workflow_dispatch:
 
 permissions: read-all

--- a/ops/jenkins/router/Dockerfile
+++ b/ops/jenkins/router/Dockerfile
@@ -1,3 +1,4 @@
+# python:3.12-slim pinned 2026-03-10
 FROM python:3.12-slim@sha256:ccc7089399c8bb65dd1fb3ed6d55efa538a3f5e7fca3f5988ac3b5b87e593bf0
 
 WORKDIR /app


### PR DESCRIPTION
## Summary

Post-merge CI/CD audit found 2 remaining consistency gaps:

- **CRITICAL**: `cflite_pr.yml` was the only required branch protection check missing the `merge_group` trigger. All other 5 required checks (CI, CodeQL, Scorecard, Semantic PR, Dependency Review) already had it. This prevented ClusterFuzzLite PR fuzzing from running in GitHub merge queue.
- **MEDIUM**: `ops/jenkins/router/Dockerfile` was the only Dockerfile without a version comment on its SHA-pinned base image. All other 3 Dockerfiles (controller, agent, clusterfuzzlite) already had comments.

## Test plan
- [x] No code changes, only CI configuration
- [ ] CI pipeline validates
- [ ] ClusterFuzzLite PR fuzzing check runs