### PR TITLE
fix(jenkins): use bare disableConcurrentBuilds compatible with installed Job DSL

### DIFF
--- a/ops/jenkins/controller/casc/jenkins.yaml
+++ b/ops/jenkins/controller/casc/jenkins.yaml
@@ -69,9 +69,7 @@ jobs:
         displayName('PR Validation')
         description('Runs the server-side extended PR contour for rldyourterm and publishes the required Jenkins Extended Validation status.')
         properties {
-          disableConcurrentBuilds {
-            abortPrevious()
-          }
+          disableConcurrentBuilds()
           githubProjectUrl(repoUrl)
           buildDiscarder {
             strategy {


### PR DESCRIPTION
## Summary

PR #71 removed what appeared to be a duplicate `disableConcurrentBuilds()`, keeping only the block form with `abortPrevious()`. However, the installed Job DSL plugin does not support `abortPrevious()` - it throws `MissingMethodException` during JCasC init, crashing the Jenkins controller on startup.

The old config had both forms as a workaround: the unsupported block form silently failed, and the bare form provided the actual behavior. This fix replaces the block form with the compatible bare `disableConcurrentBuilds()`.

## Root Cause
```
SEVERE jenkins.InitReactorRunner$1#onTaskFailed: Failed ConfigurationAsCode.init
groovy.lang.MissingMethodException: No signature of method:
  javaposse.jobdsl.plugin.structs.DescribableContext.abortPrevious()
```

## Test plan
- [x] Local syntax verified
- [ ] CI pipeline validates
- [ ] Jenkins controller starts successfully after deploy