### PR TITLE
fix(core): application cursor keys encoding and combining char handling

### DIFF
--- a/crates/app/src/gui_runtime.rs
+++ b/crates/app/src/gui_runtime.rs
@@ -568,8 +568,9 @@ fn is_runtime_palette_shortcut_key(key: Key<&str>, modifiers: ModifiersState) ->
 
 #[cfg(test)]
 fn encode_winit_key_event(key: &Key, modifiers: ModifiersState) -> Option<Vec<u8>> {
+    let modes = crate::runtime_shared::input::TerminalModeFlags::default();
     crate::runtime_shared::input::runtime_key_event_from_winit(key, modifiers)
-        .and_then(crate::runtime_shared::input::encode_runtime_key_event)
+        .and_then(|ev| crate::runtime_shared::input::encode_runtime_key_event(ev, modes))
 }
 
 #[cfg(test)]

--- a/crates/app/src/gui_runtime_terminal_io.rs
+++ b/crates/app/src/gui_runtime_terminal_io.rs
@@ -128,7 +128,10 @@ impl GuiRuntimeApp {
         // Clear text selection on any key press that produces PTY input.
         self.clear_selection();
 
-        let bytes = shared_encode_winit_key_event(event, self.interaction.modifiers);
+        let modes = crate::runtime_shared::input::TerminalModeFlags {
+            application_cursor_keys: self.terminal.application_cursor_keys_enabled(),
+        };
+        let bytes = shared_encode_winit_key_event(event, self.interaction.modifiers, modes);
 
         if let Some(ref bytes) = bytes {
             trace!(key = ?event.logical_key, len = bytes.len(), "keyboard input to PTY");

--- a/crates/app/src/pty_runtime.rs
+++ b/crates/app/src/pty_runtime.rs
@@ -310,7 +310,8 @@ pub fn run_interactive_pty(
                     continue;
                 }
 
-                if let Some(bytes) = encode_crossterm_key_event(key_event) {
+                let modes = crate::runtime_shared::input::TerminalModeFlags::default();
+                if let Some(bytes) = encode_crossterm_key_event(key_event, modes) {
                     if let Err(error) = write_all_and_flush(&mut *writer, &bytes) {
                         match handle_pty_io_failure(
                             &mut session_policy,

--- a/crates/app/src/pty_runtime/tests.rs
+++ b/crates/app/src/pty_runtime/tests.rs
@@ -8,9 +8,13 @@ use super::{
     should_flush_read_pump, tty_stdio_requirement_message,
 };
 use crate::runtime_shared::input::{
-    encode_crossterm_key_event as encode_key_event,
+    TerminalModeFlags, encode_crossterm_key_event,
     is_runtime_palette_shortcut_crossterm as is_runtime_palette_shortcut,
 };
+
+fn encode_key_event(key_event: KeyEvent) -> Option<Vec<u8>> {
+    encode_crossterm_key_event(key_event, TerminalModeFlags::default())
+}
 use crate::runtime_shared::pty_boundary::{
     PtyBoundaryPolicyDecision, classify_pty_boundary_failure,
 };

--- a/crates/app/src/runtime_shared/input.rs
+++ b/crates/app/src/runtime_shared/input.rs
@@ -6,7 +6,7 @@ use winit::event::KeyEvent as WinitKeyEvent;
 use winit::keyboard::{Key, ModifiersState, NamedKey};
 
 use crate::runtime_shared::key_encoding::{
-    csi_modified, encode_ctrl_letter, fkey_ss3_modified, tilde_modified, xterm_modifier_param,
+    cursor_key, encode_ctrl_letter, fkey_ss3_modified, tilde_modified, xterm_modifier_param,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -156,10 +156,19 @@ pub(crate) fn is_local_shutdown_key_winit(
     runtime_key_event_from_winit(&event.logical_key, modifiers).is_some_and(is_local_shutdown_key)
 }
 
-pub(crate) fn encode_runtime_key_event(key_event: RuntimeKeyEvent) -> Option<Vec<u8>> {
+#[derive(Debug, Clone, Copy, Default)]
+pub(crate) struct TerminalModeFlags {
+    pub application_cursor_keys: bool,
+}
+
+pub(crate) fn encode_runtime_key_event(
+    key_event: RuntimeKeyEvent,
+    modes: TerminalModeFlags,
+) -> Option<Vec<u8>> {
     let modifiers = key_event.modifiers;
     let mod_param = modifiers.xterm_modifier_param();
     let has_mod = mod_param > 1;
+    let app_cursor = modes.application_cursor_keys;
 
     match key_event.key {
         RuntimeKey::Enter => Some(vec![b'\r']),
@@ -170,12 +179,12 @@ pub(crate) fn encode_runtime_key_event(key_event: RuntimeKeyEvent) -> Option<Vec
         }
         RuntimeKey::Tab if !modifiers.alt && !modifiers.control => Some(vec![b'\t']),
         RuntimeKey::Escape => Some(vec![0x1b]),
-        RuntimeKey::Up => Some(csi_modified(b'A', mod_param, has_mod)),
-        RuntimeKey::Down => Some(csi_modified(b'B', mod_param, has_mod)),
-        RuntimeKey::Right => Some(csi_modified(b'C', mod_param, has_mod)),
-        RuntimeKey::Left => Some(csi_modified(b'D', mod_param, has_mod)),
-        RuntimeKey::Home => Some(csi_modified(b'H', mod_param, has_mod)),
-        RuntimeKey::End => Some(csi_modified(b'F', mod_param, has_mod)),
+        RuntimeKey::Up => Some(cursor_key(b'A', mod_param, has_mod, app_cursor)),
+        RuntimeKey::Down => Some(cursor_key(b'B', mod_param, has_mod, app_cursor)),
+        RuntimeKey::Right => Some(cursor_key(b'C', mod_param, has_mod, app_cursor)),
+        RuntimeKey::Left => Some(cursor_key(b'D', mod_param, has_mod, app_cursor)),
+        RuntimeKey::Home => Some(cursor_key(b'H', mod_param, has_mod, app_cursor)),
+        RuntimeKey::End => Some(cursor_key(b'F', mod_param, has_mod, app_cursor)),
         RuntimeKey::Delete => Some(tilde_modified(3, mod_param, has_mod)),
         RuntimeKey::Insert => Some(tilde_modified(2, mod_param, has_mod)),
         RuntimeKey::PageUp => Some(tilde_modified(5, mod_param, has_mod)),
@@ -209,20 +218,24 @@ pub(crate) fn encode_runtime_key_event(key_event: RuntimeKeyEvent) -> Option<Vec
     }
 }
 
-pub(crate) fn encode_crossterm_key_event(key_event: KeyEvent) -> Option<Vec<u8>> {
+pub(crate) fn encode_crossterm_key_event(
+    key_event: KeyEvent,
+    modes: TerminalModeFlags,
+) -> Option<Vec<u8>> {
     let key_event = runtime_key_event_from_crossterm(key_event)?;
-    encode_runtime_key_event(key_event)
+    encode_runtime_key_event(key_event, modes)
 }
 
 pub(crate) fn encode_winit_key_event(
     event: &WinitKeyEvent,
     modifiers: ModifiersState,
+    modes: TerminalModeFlags,
 ) -> Option<Vec<u8>> {
     let modifiers = RuntimeKeyModifiers::from_winit(modifiers);
     encode_winit_text_bytes(event.text.as_deref(), modifiers).or_else(|| {
         runtime_key_from_winit(&event.logical_key)
             .map(|key| RuntimeKeyEvent { key, modifiers })
-            .and_then(encode_runtime_key_event)
+            .and_then(|ev| encode_runtime_key_event(ev, modes))
     })
 }
 
@@ -286,10 +299,14 @@ fn runtime_key_from_winit_ref(key: Key<&str>) -> Option<RuntimeKey> {
 #[cfg(test)]
 mod tests {
     use super::{
-        RuntimeKeyModifiers, encode_crossterm_key_event, encode_winit_text_bytes,
-        is_runtime_palette_shortcut_winit, runtime_key_from_crossterm,
+        RuntimeKeyModifiers, TerminalModeFlags, encode_crossterm_key_event,
+        encode_winit_text_bytes, is_runtime_palette_shortcut_winit, runtime_key_from_crossterm,
         runtime_key_from_winit_borrowed,
     };
+
+    fn encode_key(key_event: KeyEvent) -> Option<Vec<u8>> {
+        encode_crossterm_key_event(key_event, TerminalModeFlags::default())
+    }
     use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
     use winit::keyboard::{Key, ModifiersState, NamedKey, SmolStr};
 
@@ -369,8 +386,79 @@ mod tests {
     #[test]
     fn crossterm_encoded_key_event_still_uses_shared_encoder() {
         assert_eq!(
-            encode_crossterm_key_event(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE)),
+            encode_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE)),
             Some(vec![b'\r'])
+        );
+    }
+
+    #[test]
+    fn application_cursor_keys_sends_ss3_for_arrows() {
+        use super::{RuntimeKey, RuntimeKeyEvent, RuntimeKeyModifiers, encode_runtime_key_event};
+        let modes = TerminalModeFlags {
+            application_cursor_keys: true,
+        };
+        let no_mods = RuntimeKeyModifiers {
+            shift: false,
+            alt: false,
+            control: false,
+            super_key: false,
+        };
+        let ev = RuntimeKeyEvent {
+            key: RuntimeKey::Up,
+            modifiers: no_mods,
+        };
+        assert_eq!(
+            encode_runtime_key_event(ev, modes),
+            Some(b"\x1bOA".to_vec())
+        );
+
+        let ev = RuntimeKeyEvent {
+            key: RuntimeKey::Down,
+            modifiers: no_mods,
+        };
+        assert_eq!(
+            encode_runtime_key_event(ev, modes),
+            Some(b"\x1bOB".to_vec())
+        );
+
+        let ev = RuntimeKeyEvent {
+            key: RuntimeKey::Right,
+            modifiers: no_mods,
+        };
+        assert_eq!(
+            encode_runtime_key_event(ev, modes),
+            Some(b"\x1bOC".to_vec())
+        );
+
+        let ev = RuntimeKeyEvent {
+            key: RuntimeKey::Left,
+            modifiers: no_mods,
+        };
+        assert_eq!(
+            encode_runtime_key_event(ev, modes),
+            Some(b"\x1bOD".to_vec())
+        );
+    }
+
+    #[test]
+    fn application_cursor_keys_uses_csi_when_modifier_present() {
+        use super::{RuntimeKey, RuntimeKeyEvent, RuntimeKeyModifiers, encode_runtime_key_event};
+        let modes = TerminalModeFlags {
+            application_cursor_keys: true,
+        };
+        let ctrl = RuntimeKeyModifiers {
+            shift: false,
+            alt: false,
+            control: true,
+            super_key: false,
+        };
+        let ev = RuntimeKeyEvent {
+            key: RuntimeKey::Up,
+            modifiers: ctrl,
+        };
+        assert_eq!(
+            encode_runtime_key_event(ev, modes),
+            Some(b"\x1b[1;5A".to_vec())
         );
     }
 }

--- a/crates/app/src/runtime_shared/key_encoding.rs
+++ b/crates/app/src/runtime_shared/key_encoding.rs
@@ -5,9 +5,16 @@ pub(crate) fn xterm_modifier_param(shift: bool, alt: bool, ctrl: bool) -> u8 {
     1 + u8::from(shift) + (u8::from(alt) << 1) + (u8::from(ctrl) << 2)
 }
 
-pub(crate) fn csi_modified(final_byte: u8, mod_param: u8, has_mod: bool) -> Vec<u8> {
+pub(crate) fn cursor_key(
+    final_byte: u8,
+    mod_param: u8,
+    has_mod: bool,
+    app_cursor: bool,
+) -> Vec<u8> {
     if has_mod {
         format!("\x1b[1;{}{}", mod_param, final_byte as char).into_bytes()
+    } else if app_cursor {
+        vec![0x1b, b'O', final_byte]
     } else {
         vec![0x1b, b'[', final_byte]
     }
@@ -55,9 +62,11 @@ mod tests {
     }
 
     #[test]
-    fn csi_modified_plain_and_with_modifier() {
-        assert_eq!(csi_modified(b'A', 1, false), b"\x1b[A");
-        assert_eq!(csi_modified(b'A', 5, true), b"\x1b[1;5A");
+    fn cursor_key_normal_and_application_mode() {
+        assert_eq!(cursor_key(b'A', 1, false, false), b"\x1b[A");
+        assert_eq!(cursor_key(b'A', 1, false, true), b"\x1bOA");
+        assert_eq!(cursor_key(b'A', 5, true, false), b"\x1b[1;5A");
+        assert_eq!(cursor_key(b'A', 5, true, true), b"\x1b[1;5A");
     }
 
     #[test]

--- a/crates/core/src/state/actions.rs
+++ b/crates/core/src/state/actions.rs
@@ -20,6 +20,13 @@ impl TerminalState {
         let width = self.grid.width();
         let char_width = UnicodeWidthChar::width(ch).unwrap_or(1) as u8;
 
+        // Width-0 characters (combining marks, variation selectors) cannot be
+        // represented in a single-char-per-cell grid without grapheme cluster
+        // support. Skip the grid put to avoid creating phantom continuation cells.
+        if char_width == 0 {
+            return;
+        }
+
         // VT100 deferred wrap: if wrap_pending is set from a previous print
         // at the last column, execute the actual wrap now before printing.
         if self.cursor.wrap_pending {

--- a/crates/core/src/state/mod.rs
+++ b/crates/core/src/state/mod.rs
@@ -168,13 +168,11 @@ impl TerminalState {
         self.synchronized_output
     }
 
-    #[cfg(test)]
-    pub(crate) fn application_cursor_keys_enabled(&self) -> bool {
+    pub fn application_cursor_keys_enabled(&self) -> bool {
         self.application_cursor_keys
     }
 
-    #[cfg(test)]
-    pub(crate) fn application_keypad_mode_enabled(&self) -> bool {
+    pub fn application_keypad_mode_enabled(&self) -> bool {
         self.application_keypad_mode
     }
 

--- a/crates/core/src/state/tests_feed.rs
+++ b/crates/core/src/state/tests_feed.rs
@@ -346,6 +346,14 @@ fn sgr_invalid_color_does_not_eat_subsequent_params() {
 }
 
 #[test]
+fn combining_mark_does_not_create_phantom_cell() {
+    let mut state = TerminalState::new(10, 2, 5);
+    let _ = state.feed("e\u{0301}".as_bytes());
+    assert_eq!(state.cursor.col, 1);
+    assert_eq!(state.grid.get_char(0, 0), Ok('e'));
+}
+
+#[test]
 fn tab_advances_to_next_stop() {
     let mut state = TerminalState::new(20, 1, 5);
     let _ = state.feed(b"AB\t");


### PR DESCRIPTION
## Summary

Three functional fixes at the core/app layer, addressing bugs found during competitive terminal analysis.

### Bug Fixes

- **Application cursor keys (DECCKM ?1h)**: Arrow, Home, End keys now send SS3 sequences (\x1bOA-D, \x1bOH, \x1bOF) when application cursor mode is active, instead of always using CSI format. Modified keys (Ctrl+Arrow etc.) correctly continue using CSI. **This fixes vim/tmux navigation** which relies on SS3 encoding in normal mode.

- **Combining characters (width-0)**: Characters with `unicode_width == 0` (combining diacritical marks, variation selectors) are now skipped in `apply_print` instead of being placed as phantom continuation cells. Prevents grid corruption from combining marks like U+0301 (acute accent).

- **Mode-aware key encoding**: `encode_runtime_key_event` now accepts `TerminalModeFlags` parameter, enabling the encoder to respect terminal mode state. `application_cursor_keys_enabled()` promoted from `#[cfg(test)] pub(crate)` to `pub`.

### Architecture

The key encoding pipeline now reads terminal mode flags at the call site (GUI runtime reads from `self.terminal`, PTY runtime uses defaults since it has no terminal state machine).

### Tests
- 3 new regression tests: DECCKM arrow encoding (2), combining char skip (1)
- Total: **893 tests**, 0 failures (was 890)

## Test plan
- [x] `cargo clippy -D warnings` passes (0 warnings)
- [x] `cargo fmt --check` passes
- [x] `cargo test --workspace` passes (893/893)
- [x] New tests verify DECCKM SS3 encoding
- [ ] CI pipeline validates
- [ ] Jenkins Extended Validation passes