### PR TITLE
perf(core): pack Attrs boolean fields into u16 bitflags

### DIFF
--- a/crates/app/src/gui_runtime/tests/runtime.rs
+++ b/crates/app/src/gui_runtime/tests/runtime.rs
@@ -292,12 +292,10 @@ fn color_to_u32_rgb_constructs_correctly() {
 
 #[test]
 fn resolve_cell_colors_inverse_swaps_fg_bg() {
-    let attrs = Attrs {
-        fg: Color::Indexed(1),
-        bg: Color::Indexed(2),
-        inverse: true,
-        ..Attrs::default()
-    };
+    let attrs = Attrs::default()
+        .with_fg(Color::Indexed(1))
+        .with_bg(Color::Indexed(2))
+        .with_inverse();
     let (fg, bg) = resolve_cell_colors(&attrs);
     assert_eq!(fg, ANSI_PALETTE[2]);
     assert_eq!(bg, ANSI_PALETTE[1]);
@@ -305,11 +303,9 @@ fn resolve_cell_colors_inverse_swaps_fg_bg() {
 
 #[test]
 fn resolve_cell_colors_dim_halves_fg() {
-    let attrs = Attrs {
-        fg: Color::Rgb(200, 100, 50),
-        dim: true,
-        ..Attrs::default()
-    };
+    let attrs = Attrs::default()
+        .with_fg(Color::Rgb(200, 100, 50))
+        .with_dim();
     let (fg, _bg) = resolve_cell_colors(&attrs);
     assert_eq!(fg, rldyourterm_render_cpu::rgb_to_u32(100, 50, 25));
 }

--- a/crates/core/src/grid/mod.rs
+++ b/crates/core/src/grid/mod.rs
@@ -20,21 +20,165 @@ pub enum Color {
     Rgb(u8, u8, u8),
 }
 
+const ATTR_BOLD: u16 = 1 << 0;
+const ATTR_DIM: u16 = 1 << 1;
+const ATTR_ITALIC: u16 = 1 << 2;
+const ATTR_UNDERLINE: u16 = 1 << 3;
+const ATTR_DOUBLE_UNDERLINE: u16 = 1 << 4;
+const ATTR_OVERLINE: u16 = 1 << 5;
+const ATTR_INVERSE: u16 = 1 << 6;
+const ATTR_HIDDEN: u16 = 1 << 7;
+const ATTR_BLINK: u16 = 1 << 8;
+const ATTR_STRIKETHROUGH: u16 = 1 << 9;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct Attrs {
     pub fg: Color,
     pub bg: Color,
-    pub bold: bool,
-    pub dim: bool,
-    pub italic: bool,
-    pub underline: bool,
-    pub double_underline: bool,
-    pub overline: bool,
     pub underline_color: Color,
-    pub inverse: bool,
-    pub hidden: bool,
-    pub blink: bool,
-    pub strikethrough: bool,
+    flags: u16,
+}
+
+impl Attrs {
+    fn get(&self, flag: u16) -> bool {
+        self.flags & flag != 0
+    }
+
+    fn set(&mut self, flag: u16, value: bool) {
+        if value {
+            self.flags |= flag;
+        } else {
+            self.flags &= !flag;
+        }
+    }
+
+    pub fn bold(&self) -> bool {
+        self.get(ATTR_BOLD)
+    }
+    pub fn set_bold(&mut self, v: bool) {
+        self.set(ATTR_BOLD, v);
+    }
+    pub fn dim(&self) -> bool {
+        self.get(ATTR_DIM)
+    }
+    pub fn set_dim(&mut self, v: bool) {
+        self.set(ATTR_DIM, v);
+    }
+    pub fn italic(&self) -> bool {
+        self.get(ATTR_ITALIC)
+    }
+    pub fn set_italic(&mut self, v: bool) {
+        self.set(ATTR_ITALIC, v);
+    }
+    pub fn underline(&self) -> bool {
+        self.get(ATTR_UNDERLINE)
+    }
+    pub fn set_underline(&mut self, v: bool) {
+        self.set(ATTR_UNDERLINE, v);
+    }
+    pub fn double_underline(&self) -> bool {
+        self.get(ATTR_DOUBLE_UNDERLINE)
+    }
+    pub fn set_double_underline(&mut self, v: bool) {
+        self.set(ATTR_DOUBLE_UNDERLINE, v);
+    }
+    pub fn overline(&self) -> bool {
+        self.get(ATTR_OVERLINE)
+    }
+    pub fn set_overline(&mut self, v: bool) {
+        self.set(ATTR_OVERLINE, v);
+    }
+    pub fn inverse(&self) -> bool {
+        self.get(ATTR_INVERSE)
+    }
+    pub fn set_inverse(&mut self, v: bool) {
+        self.set(ATTR_INVERSE, v);
+    }
+    pub fn hidden(&self) -> bool {
+        self.get(ATTR_HIDDEN)
+    }
+    pub fn set_hidden(&mut self, v: bool) {
+        self.set(ATTR_HIDDEN, v);
+    }
+    pub fn blink(&self) -> bool {
+        self.get(ATTR_BLINK)
+    }
+    pub fn set_blink(&mut self, v: bool) {
+        self.set(ATTR_BLINK, v);
+    }
+    pub fn strikethrough(&self) -> bool {
+        self.get(ATTR_STRIKETHROUGH)
+    }
+    pub fn set_strikethrough(&mut self, v: bool) {
+        self.set(ATTR_STRIKETHROUGH, v);
+    }
+
+    #[must_use]
+    pub fn with_fg(mut self, color: Color) -> Self {
+        self.fg = color;
+        self
+    }
+    #[must_use]
+    pub fn with_bg(mut self, color: Color) -> Self {
+        self.bg = color;
+        self
+    }
+    #[must_use]
+    pub fn with_underline_color_value(mut self, color: Color) -> Self {
+        self.underline_color = color;
+        self
+    }
+
+    #[must_use]
+    pub fn with_bold(mut self) -> Self {
+        self.set_bold(true);
+        self
+    }
+    #[must_use]
+    pub fn with_dim(mut self) -> Self {
+        self.set_dim(true);
+        self
+    }
+    #[must_use]
+    pub fn with_italic(mut self) -> Self {
+        self.set_italic(true);
+        self
+    }
+    #[must_use]
+    pub fn with_underline(mut self) -> Self {
+        self.set_underline(true);
+        self
+    }
+    #[must_use]
+    pub fn with_double_underline(mut self) -> Self {
+        self.set_double_underline(true);
+        self
+    }
+    #[must_use]
+    pub fn with_overline(mut self) -> Self {
+        self.set_overline(true);
+        self
+    }
+    #[must_use]
+    pub fn with_inverse(mut self) -> Self {
+        self.set_inverse(true);
+        self
+    }
+    #[must_use]
+    pub fn with_hidden(mut self) -> Self {
+        self.set_hidden(true);
+        self
+    }
+    #[must_use]
+    pub fn with_blink(mut self) -> Self {
+        self.set_blink(true);
+        self
+    }
+    #[must_use]
+    pub fn with_strikethrough(mut self) -> Self {
+        self.set_strikethrough(true);
+        self
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/core/src/grid/tests.rs
+++ b/crates/core/src/grid/tests.rs
@@ -39,25 +39,18 @@ fn put_char_out_of_bounds_is_error() {
 #[test]
 fn put_char_stores_attrs() {
     let mut grid = Grid::new(4, 2);
-    let attrs = Attrs {
-        fg: Color::Indexed(1),
-        bold: true,
-        ..Attrs::default()
-    };
+    let attrs = Attrs::default().with_fg(Color::Indexed(1)).with_bold();
     grid.put_char(0, 0, 'A', attrs).expect("valid put");
     let cell = grid.get_cell(0, 0).expect("valid get");
     assert_eq!(cell.ch, 'A');
     assert_eq!(cell.attrs.fg, Color::Indexed(1));
-    assert!(cell.attrs.bold);
+    assert!(cell.attrs.bold());
 }
 
 #[test]
 fn clear_resets_attrs_to_default() {
     let mut grid = Grid::new(2, 2);
-    let attrs = Attrs {
-        fg: Color::Rgb(255, 0, 0),
-        ..Attrs::default()
-    };
+    let attrs = Attrs::default().with_fg(Color::Rgb(255, 0, 0));
     grid.put_char(0, 0, 'X', attrs).expect("valid put");
     grid.clear();
     let cell = grid.get_cell(0, 0).expect("valid get");

--- a/crates/core/src/state/actions.rs
+++ b/crates/core/src/state/actions.rs
@@ -279,31 +279,31 @@ impl TerminalState {
             let code = params[i].unwrap_or(0);
             match code {
                 0 => self.pen = Attrs::default(),
-                1 => self.pen.bold = true,
-                2 => self.pen.dim = true,
-                3 => self.pen.italic = true,
-                4 => self.pen.underline = true,
-                5 | 6 => self.pen.blink = true,
-                7 => self.pen.inverse = true,
-                8 => self.pen.hidden = true,
-                9 => self.pen.strikethrough = true,
+                1 => self.pen.set_bold(true),
+                2 => self.pen.set_dim(true),
+                3 => self.pen.set_italic(true),
+                4 => self.pen.set_underline(true),
+                5 | 6 => self.pen.set_blink(true),
+                7 => self.pen.set_inverse(true),
+                8 => self.pen.set_hidden(true),
+                9 => self.pen.set_strikethrough(true),
                 21 => {
-                    self.pen.underline = false;
-                    self.pen.double_underline = true;
+                    self.pen.set_underline(false);
+                    self.pen.set_double_underline(true);
                 }
                 22 => {
-                    self.pen.bold = false;
-                    self.pen.dim = false;
+                    self.pen.set_bold(false);
+                    self.pen.set_dim(false);
                 }
-                23 => self.pen.italic = false,
+                23 => self.pen.set_italic(false),
                 24 => {
-                    self.pen.underline = false;
-                    self.pen.double_underline = false;
+                    self.pen.set_underline(false);
+                    self.pen.set_double_underline(false);
                 }
-                25 => self.pen.blink = false,
-                27 => self.pen.inverse = false,
-                28 => self.pen.hidden = false,
-                29 => self.pen.strikethrough = false,
+                25 => self.pen.set_blink(false),
+                27 => self.pen.set_inverse(false),
+                28 => self.pen.set_hidden(false),
+                29 => self.pen.set_strikethrough(false),
                 30..=37 => self.pen.fg = Color::Indexed((code - 30) as u8),
                 38 => {
                     if let Some(color) = parse_extended_color(params, &mut i) {
@@ -318,8 +318,8 @@ impl TerminalState {
                     }
                 }
                 49 => self.pen.bg = Color::Default,
-                53 => self.pen.overline = true,
-                55 => self.pen.overline = false,
+                53 => self.pen.set_overline(true),
+                55 => self.pen.set_overline(false),
                 58 => {
                     if let Some(color) = parse_extended_color(params, &mut i) {
                         self.pen.underline_color = color;

--- a/crates/core/src/state/tests_feed.rs
+++ b/crates/core/src/state/tests_feed.rs
@@ -292,11 +292,11 @@ fn sgr_sets_pen_attributes() {
     let mut state = TerminalState::new(10, 2, 5);
     // ESC[1;31m = bold + red fg
     let _ = state.feed(b"\x1b[1;31mA");
-    assert!(state.pen.bold);
+    assert!(state.pen.bold());
     assert_eq!(state.pen.fg, Color::Indexed(1));
     let cell = state.grid.get_cell(0, 0).expect("cell");
     assert_eq!(cell.ch, 'A');
-    assert!(cell.attrs.bold);
+    assert!(cell.attrs.bold());
     assert_eq!(cell.attrs.fg, Color::Indexed(1));
 }
 
@@ -342,7 +342,7 @@ fn sgr_invalid_color_does_not_eat_subsequent_params() {
     let mut state = TerminalState::new(10, 2, 5);
     let _ = state.feed(b"\x1b[38;5;256;1mX");
     assert_eq!(state.pen.fg, Color::Default);
-    assert!(state.pen.bold);
+    assert!(state.pen.bold());
 }
 
 #[test]

--- a/crates/core/src/state/tests_modes.rs
+++ b/crates/core/src/state/tests_modes.rs
@@ -10,7 +10,7 @@ use super::{MouseFormat, MouseMode, TerminalState};
 fn cursor_save_restore_preserves_pen() {
     let mut state = TerminalState::new(10, 5, 5);
     let _ = state.feed(b"\x1b[1;31m\x1b7\x1b[0m\x1b8");
-    assert!(state.pen.bold);
+    assert!(state.pen.bold());
     assert_eq!(state.pen.fg, Color::Indexed(1));
 }
 
@@ -18,25 +18,25 @@ fn cursor_save_restore_preserves_pen() {
 fn sgr_hidden_sets_and_resets() {
     let mut state = TerminalState::new(10, 5, 5);
     let _ = state.feed(b"\x1b[8m");
-    assert!(state.pen.hidden);
+    assert!(state.pen.hidden());
     let _ = state.feed(b"\x1b[28m");
-    assert!(!state.pen.hidden);
+    assert!(!state.pen.hidden());
 }
 
 #[test]
 fn sgr_blink_sets_and_resets() {
     let mut state = TerminalState::new(10, 5, 5);
     let _ = state.feed(b"\x1b[5m");
-    assert!(state.pen.blink);
+    assert!(state.pen.blink());
     let _ = state.feed(b"\x1b[25m");
-    assert!(!state.pen.blink);
+    assert!(!state.pen.blink());
     // SGR 6 (rapid blink) also sets blink
     let _ = state.feed(b"\x1b[6m");
-    assert!(state.pen.blink);
+    assert!(state.pen.blink());
     // SGR 0 resets all
     let _ = state.feed(b"\x1b[0m");
-    assert!(!state.pen.blink);
-    assert!(!state.pen.hidden);
+    assert!(!state.pen.blink());
+    assert!(!state.pen.hidden());
 }
 
 #[test]
@@ -876,21 +876,21 @@ fn cwd_and_window_title_are_independent() {
 fn sgr_double_underline_sets_and_resets() {
     let mut state = TerminalState::new(10, 5, 5);
     let _ = state.feed(b"\x1b[21m");
-    assert!(state.pen.double_underline);
-    assert!(!state.pen.underline);
+    assert!(state.pen.double_underline());
+    assert!(!state.pen.underline());
     // SGR 24 resets both underline and double_underline
     let _ = state.feed(b"\x1b[24m");
-    assert!(!state.pen.double_underline);
-    assert!(!state.pen.underline);
+    assert!(!state.pen.double_underline());
+    assert!(!state.pen.underline());
 }
 
 #[test]
 fn sgr_overline_sets_and_resets() {
     let mut state = TerminalState::new(10, 5, 5);
     let _ = state.feed(b"\x1b[53m");
-    assert!(state.pen.overline);
+    assert!(state.pen.overline());
     let _ = state.feed(b"\x1b[55m");
-    assert!(!state.pen.overline);
+    assert!(!state.pen.overline());
 }
 
 #[test]

--- a/crates/core/src/state/tests_stress.rs
+++ b/crates/core/src/state/tests_stress.rs
@@ -362,7 +362,7 @@ fn sgr_17_params_via_state_feed() {
     // 17 params: first 16 consumed, 17th silently truncated
     let _ = state.feed(b"\x1b[1;2;3;4;5;7;9;31;32;33;34;35;36;37;38;39;40mX");
     // Parser should not crash. Bold (1) should apply from first param.
-    assert!(state.pen.bold);
+    assert!(state.pen.bold());
 }
 
 #[test]

--- a/crates/features/render_cpu/src/rasterize.rs
+++ b/crates/features/render_cpu/src/rasterize.rs
@@ -330,10 +330,19 @@ fn render_grid_row_cells(
             }
         }
 
-        let glyph_hidden_by_blink = cell.attrs.blink && !blink_visible;
+        let glyph_hidden_by_blink = cell.attrs.blink() && !blink_visible;
         if cell.ch != ' ' && !glyph_hidden_by_blink {
             let glyph = glyph_cache.get(cell.ch);
-            draw_glyph_blended(buffer, width, height, x, base_y, glyph, fg, cell.attrs.bold);
+            draw_glyph_blended(
+                buffer,
+                width,
+                height,
+                x,
+                base_y,
+                glyph,
+                fg,
+                cell.attrs.bold(),
+            );
         }
 
         // Resolve underline decoration color (SGR 58 or fallback to fg).
@@ -343,28 +352,28 @@ fn render_grid_row_cells(
             color_to_u32(cell.attrs.underline_color, DEFAULT_FG)
         };
 
-        if cell.attrs.underline {
+        if cell.attrs.underline() {
             draw_underline(buffer, width, height, x, base_y, ul_color);
             if cell_pixel_width > CELL_WIDTH && col + 1 < visible_cols {
                 draw_underline(buffer, width, height, x + CELL_WIDTH, base_y, ul_color);
             }
         }
 
-        if cell.attrs.double_underline {
+        if cell.attrs.double_underline() {
             draw_double_underline(buffer, width, height, x, base_y, ul_color);
             if cell_pixel_width > CELL_WIDTH && col + 1 < visible_cols {
                 draw_double_underline(buffer, width, height, x + CELL_WIDTH, base_y, ul_color);
             }
         }
 
-        if cell.attrs.strikethrough {
+        if cell.attrs.strikethrough() {
             draw_strikethrough(buffer, width, height, x, base_y, fg);
             if cell_pixel_width > CELL_WIDTH && col + 1 < visible_cols {
                 draw_strikethrough(buffer, width, height, x + CELL_WIDTH, base_y, fg);
             }
         }
 
-        if cell.attrs.overline {
+        if cell.attrs.overline() {
             draw_overline(buffer, width, height, x, base_y, fg);
             if cell_pixel_width > CELL_WIDTH && col + 1 < visible_cols {
                 draw_overline(buffer, width, height, x + CELL_WIDTH, base_y, fg);
@@ -377,16 +386,16 @@ pub fn resolve_cell_colors(attrs: &Attrs) -> (u32, u32) {
     let mut fg = color_to_u32(attrs.fg, DEFAULT_FG);
     let mut bg = color_to_u32(attrs.bg, DEFAULT_BG);
 
-    if attrs.dim {
+    if attrs.dim() {
         let (r, g, b) = u32_to_rgb(fg);
         fg = rgb_to_u32(r / 2, g / 2, b / 2);
     }
 
-    if attrs.inverse {
+    if attrs.inverse() {
         std::mem::swap(&mut fg, &mut bg);
     }
 
-    if attrs.hidden {
+    if attrs.hidden() {
         fg = bg;
     }
 

--- a/crates/features/render_cpu/src/tests.rs
+++ b/crates/features/render_cpu/src/tests.rs
@@ -615,33 +615,26 @@ fn resolve_cell_colors_default_attrs_produce_default_colors() {
 
 #[test]
 fn resolve_cell_colors_hidden_makes_fg_equal_bg() {
-    let attrs = Attrs {
-        hidden: true,
-        ..Attrs::default()
-    };
+    let attrs = Attrs::default().with_hidden();
     let (fg, bg) = resolve_cell_colors(&attrs);
     assert_eq!(fg, bg, "hidden text: fg must equal bg");
 }
 
 #[test]
 fn resolve_cell_colors_dim_halves_fg_brightness() {
-    let attrs = Attrs {
-        fg: Color::Rgb(200, 100, 50),
-        dim: true,
-        ..Attrs::default()
-    };
+    let attrs = Attrs::default()
+        .with_fg(Color::Rgb(200, 100, 50))
+        .with_dim();
     let (fg, _bg) = resolve_cell_colors(&attrs);
     assert_eq!(fg, rgb_to_u32(100, 50, 25));
 }
 
 #[test]
 fn resolve_cell_colors_inverse_swaps_fg_bg() {
-    let attrs = Attrs {
-        fg: Color::Rgb(255, 0, 0),
-        bg: Color::Rgb(0, 0, 255),
-        inverse: true,
-        ..Attrs::default()
-    };
+    let attrs = Attrs::default()
+        .with_fg(Color::Rgb(255, 0, 0))
+        .with_bg(Color::Rgb(0, 0, 255))
+        .with_inverse();
     let (fg, bg) = resolve_cell_colors(&attrs);
     assert_eq!(fg, rgb_to_u32(0, 0, 255), "fg should be original bg");
     assert_eq!(bg, rgb_to_u32(255, 0, 0), "bg should be original fg");

--- a/crates/features/render_cpu/src/tests_stress.rs
+++ b/crates/features/render_cpu/src/tests_stress.rs
@@ -323,10 +323,7 @@ fn bold_text_produces_wider_glyph_coverage() {
         .put_char(0, 0, 'H', Attrs::default())
         .expect("put normal H");
     // Place bold 'H' at col 2.
-    let bold_attrs = Attrs {
-        bold: true,
-        ..Attrs::default()
-    };
+    let bold_attrs = Attrs::default().with_bold();
     state
         .grid
         .put_char(0, 2, 'H', bold_attrs)
@@ -364,10 +361,7 @@ fn inverse_attr_paints_cell_bg_with_fg_color() {
     let mut state = state_with_default_scrollback(cols as u16, rows as u16);
     state.cursor.visible = false;
 
-    let inverse_attrs = Attrs {
-        inverse: true,
-        ..Attrs::default()
-    };
+    let inverse_attrs = Attrs::default().with_inverse();
     // A space with inverse: bg becomes DEFAULT_FG color, fg becomes DEFAULT_BG color.
     // Since the char is space, only the background fill matters.
     state
@@ -402,15 +396,8 @@ fn dim_attr_halves_rendered_pixel_brightness() {
     state.cursor.visible = false;
 
     let bright_fg = Color::Rgb(200, 100, 50);
-    let normal_attrs = Attrs {
-        fg: bright_fg,
-        ..Attrs::default()
-    };
-    let dim_attrs = Attrs {
-        fg: bright_fg,
-        dim: true,
-        ..Attrs::default()
-    };
+    let normal_attrs = Attrs::default().with_fg(bright_fg);
+    let dim_attrs = Attrs::default().with_fg(bright_fg).with_dim();
 
     state
         .grid
@@ -458,11 +445,9 @@ fn strikethrough_draws_line_at_mid_height() {
     let mut state = state_with_default_scrollback(cols as u16, rows as u16);
     state.cursor.visible = false;
 
-    let st_attrs = Attrs {
-        fg: Color::Rgb(255, 0, 0),
-        strikethrough: true,
-        ..Attrs::default()
-    };
+    let st_attrs = Attrs::default()
+        .with_fg(Color::Rgb(255, 0, 0))
+        .with_strikethrough();
     state
         .grid
         .put_char(0, 0, ' ', st_attrs)
@@ -501,11 +486,9 @@ fn underline_draws_line_at_cell_bottom() {
     let mut state = state_with_default_scrollback(cols as u16, rows as u16);
     state.cursor.visible = false;
 
-    let ul_attrs = Attrs {
-        fg: Color::Rgb(0, 255, 0),
-        underline: true,
-        ..Attrs::default()
-    };
+    let ul_attrs = Attrs::default()
+        .with_fg(Color::Rgb(0, 255, 0))
+        .with_underline();
     state
         .grid
         .put_char(0, 0, ' ', ul_attrs)

--- a/crates/features/render_gpu/src/cell_data.rs
+++ b/crates/features/render_gpu/src/cell_data.rs
@@ -14,34 +14,34 @@ use tracing::{debug, info};
 #[inline]
 pub(super) fn pack_cell_flags(slot: u16, attrs: &super::Attrs) -> u32 {
     let mut flags = slot as u32;
-    if attrs.bold {
+    if attrs.bold() {
         flags |= ATTR_BOLD;
     }
-    if attrs.italic {
+    if attrs.italic() {
         flags |= ATTR_ITALIC;
     }
-    if attrs.underline {
+    if attrs.underline() {
         flags |= ATTR_UNDERLINE;
     }
-    if attrs.strikethrough {
+    if attrs.strikethrough() {
         flags |= ATTR_STRIKETHROUGH;
     }
-    if attrs.dim {
+    if attrs.dim() {
         flags |= ATTR_DIM;
     }
-    if attrs.inverse {
+    if attrs.inverse() {
         flags |= ATTR_INVERSE;
     }
-    if attrs.blink {
+    if attrs.blink() {
         flags |= ATTR_BLINK;
     }
-    if attrs.hidden {
+    if attrs.hidden() {
         flags |= ATTR_HIDDEN;
     }
-    if attrs.double_underline {
+    if attrs.double_underline() {
         flags |= ATTR_DOUBLE_UNDERLINE;
     }
-    if attrs.overline {
+    if attrs.overline() {
         flags |= ATTR_OVERLINE;
     }
     flags
@@ -156,7 +156,7 @@ impl GpuBackend {
                 }
 
                 // Resolve underline decoration color for shader (SGR 58).
-                let ul_color = if attrs.underline || attrs.double_underline {
+                let ul_color = if attrs.underline() || attrs.double_underline() {
                     if attrs.underline_color == Color::Default {
                         fg
                     } else {

--- a/crates/features/render_gpu/src/tests/mod.rs
+++ b/crates/features/render_gpu/src/tests/mod.rs
@@ -504,10 +504,7 @@ fn gpu_render_error_mapping_is_deterministic() {
 
 #[test]
 fn pack_cell_flags_sets_double_underline_bit() {
-    let attrs = Attrs {
-        double_underline: true,
-        ..Attrs::default()
-    };
+    let attrs = Attrs::default().with_double_underline();
     let flags = pack_cell_flags(42, &attrs);
     assert_eq!(flags & 0xFFFF, 42, "lower 16 bits = slot");
     assert_ne!(
@@ -524,10 +521,7 @@ fn pack_cell_flags_sets_double_underline_bit() {
 
 #[test]
 fn pack_cell_flags_sets_overline_bit() {
-    let attrs = Attrs {
-        overline: true,
-        ..Attrs::default()
-    };
+    let attrs = Attrs::default().with_overline();
     let flags = pack_cell_flags(0, &attrs);
     assert_ne!(flags & ATTR_OVERLINE, 0, "overline bit must be set");
 }
@@ -536,19 +530,17 @@ fn pack_cell_flags_sets_overline_bit() {
 fn pack_cell_flags_wide_and_continuation_are_independent_of_attrs() {
     // ATTR_WIDE and ATTR_CONTINUATION are set per-cell in write_row_instances,
     // not by pack_cell_flags. Verify attrs alone don't set them.
-    let all_attrs = Attrs {
-        bold: true,
-        italic: true,
-        underline: true,
-        strikethrough: true,
-        dim: true,
-        inverse: true,
-        blink: true,
-        hidden: true,
-        double_underline: true,
-        overline: true,
-        ..Attrs::default()
-    };
+    let all_attrs = Attrs::default()
+        .with_bold()
+        .with_italic()
+        .with_underline()
+        .with_strikethrough()
+        .with_dim()
+        .with_inverse()
+        .with_blink()
+        .with_hidden()
+        .with_double_underline()
+        .with_overline();
     let flags = pack_cell_flags(0, &all_attrs);
     assert_eq!(flags & ATTR_WIDE, 0, "ATTR_WIDE must not be set by attrs");
     assert_eq!(
@@ -560,19 +552,17 @@ fn pack_cell_flags_wide_and_continuation_are_independent_of_attrs() {
 
 #[test]
 fn pack_cell_flags_all_bits_combined() {
-    let attrs = Attrs {
-        bold: true,
-        italic: true,
-        underline: true,
-        strikethrough: true,
-        dim: true,
-        inverse: true,
-        blink: true,
-        hidden: true,
-        double_underline: true,
-        overline: true,
-        ..Attrs::default()
-    };
+    let attrs = Attrs::default()
+        .with_bold()
+        .with_italic()
+        .with_underline()
+        .with_strikethrough()
+        .with_dim()
+        .with_inverse()
+        .with_blink()
+        .with_hidden()
+        .with_double_underline()
+        .with_overline();
     let flags = pack_cell_flags(0xFFFF, &attrs);
     assert_ne!(flags & ATTR_BOLD, 0);
     assert_ne!(flags & ATTR_ITALIC, 0);

--- a/crates/features/render_gpu/src/tests/stress.rs
+++ b/crates/features/render_gpu/src/tests/stress.rs
@@ -6,15 +6,25 @@ use super::super::*;
 #[test]
 fn stress_pack_cell_flags_all_64_combinations() {
     for bits in 0..64u8 {
-        let attrs = Attrs {
-            bold: bits & 1 != 0,
-            italic: bits & 2 != 0,
-            underline: bits & 4 != 0,
-            strikethrough: bits & 8 != 0,
-            dim: bits & 16 != 0,
-            inverse: bits & 32 != 0,
-            ..Default::default()
-        };
+        let mut attrs = Attrs::default();
+        if bits & 1 != 0 {
+            attrs = attrs.with_bold();
+        }
+        if bits & 2 != 0 {
+            attrs = attrs.with_italic();
+        }
+        if bits & 4 != 0 {
+            attrs = attrs.with_underline();
+        }
+        if bits & 8 != 0 {
+            attrs = attrs.with_strikethrough();
+        }
+        if bits & 16 != 0 {
+            attrs = attrs.with_dim();
+        }
+        if bits & 32 != 0 {
+            attrs = attrs.with_inverse();
+        }
         let slot = 12345u16;
         let flags = pack_cell_flags(slot, &attrs);
         assert_eq!(
@@ -22,26 +32,24 @@ fn stress_pack_cell_flags_all_64_combinations() {
             slot as u32,
             "atlas index corrupted at bits={bits}"
         );
-        assert_eq!((flags & ATTR_BOLD != 0), attrs.bold);
-        assert_eq!((flags & ATTR_ITALIC != 0), attrs.italic);
-        assert_eq!((flags & ATTR_UNDERLINE != 0), attrs.underline);
-        assert_eq!((flags & ATTR_STRIKETHROUGH != 0), attrs.strikethrough);
-        assert_eq!((flags & ATTR_DIM != 0), attrs.dim);
-        assert_eq!((flags & ATTR_INVERSE != 0), attrs.inverse);
+        assert_eq!((flags & ATTR_BOLD != 0), attrs.bold());
+        assert_eq!((flags & ATTR_ITALIC != 0), attrs.italic());
+        assert_eq!((flags & ATTR_UNDERLINE != 0), attrs.underline());
+        assert_eq!((flags & ATTR_STRIKETHROUGH != 0), attrs.strikethrough());
+        assert_eq!((flags & ATTR_DIM != 0), attrs.dim());
+        assert_eq!((flags & ATTR_INVERSE != 0), attrs.inverse());
     }
 }
 
 #[test]
 fn stress_pack_cell_flags_max_atlas_slot() {
-    let attrs = Attrs {
-        bold: true,
-        italic: true,
-        underline: true,
-        strikethrough: true,
-        dim: true,
-        inverse: true,
-        ..Default::default()
-    };
+    let attrs = Attrs::default()
+        .with_bold()
+        .with_italic()
+        .with_underline()
+        .with_strikethrough()
+        .with_dim()
+        .with_inverse();
     let slot = 0xFFFFu16;
     let flags = pack_cell_flags(slot, &attrs);
     assert_eq!(flags & 0xFFFF, 0xFFFF);

--- a/crates/integration-tests/tests/escape_sequence_coverage.rs
+++ b/crates/integration-tests/tests/escape_sequence_coverage.rs
@@ -100,7 +100,10 @@ fn cursor_save_restore_decsc_decrc() {
     // Pen should be restored - verify by printing and checking attributes
     feed_bytes(&mut t, b"X");
     let cells = t.grid.row_cells(7).unwrap();
-    assert!(cells[14].attrs.bold, "bold should be restored after DECRC");
+    assert!(
+        cells[14].attrs.bold(),
+        "bold should be restored after DECRC"
+    );
 }
 
 // ── Erase operations ────────────────────────────────────────
@@ -493,10 +496,10 @@ fn sgr_reset_clears_all() {
     // Set multiple attributes
     feed_bytes(&mut t, b"\x1b[1;3;4;7;38;2;255;0;0mStyled");
     let cells = t.grid.row_cells(0).unwrap();
-    assert!(cells[0].attrs.bold);
-    assert!(cells[0].attrs.italic);
-    assert!(cells[0].attrs.underline);
-    assert!(cells[0].attrs.inverse);
+    assert!(cells[0].attrs.bold());
+    assert!(cells[0].attrs.italic());
+    assert!(cells[0].attrs.underline());
+    assert!(cells[0].attrs.inverse());
     assert_eq!(cells[0].attrs.fg, Color::Rgb(255, 0, 0));
 
     // SGR 0: reset all
@@ -512,12 +515,12 @@ fn sgr_combined_attributes() {
     // Bold + italic + underline + strikethrough in one sequence
     feed_bytes(&mut t, b"\x1b[1;3;4;9mX");
     let cells = t.grid.row_cells(0).unwrap();
-    assert!(cells[0].attrs.bold);
-    assert!(cells[0].attrs.italic);
-    assert!(cells[0].attrs.underline);
-    assert!(cells[0].attrs.strikethrough);
-    assert!(!cells[0].attrs.dim); // not set
-    assert!(!cells[0].attrs.inverse); // not set
+    assert!(cells[0].attrs.bold());
+    assert!(cells[0].attrs.italic());
+    assert!(cells[0].attrs.underline());
+    assert!(cells[0].attrs.strikethrough());
+    assert!(!cells[0].attrs.dim()); // not set
+    assert!(!cells[0].attrs.inverse()); // not set
 }
 
 #[test]
@@ -526,7 +529,7 @@ fn sgr_underline_color() {
     // Set underline + underline color (SGR 58;2;R;G;B)
     feed_bytes(&mut t, b"\x1b[4;58;2;0;128;255mA");
     let cells = t.grid.row_cells(0).unwrap();
-    assert!(cells[0].attrs.underline);
+    assert!(cells[0].attrs.underline());
     assert_eq!(cells[0].attrs.underline_color, Color::Rgb(0, 128, 255));
 
     // Reset underline color (SGR 59)
@@ -534,7 +537,7 @@ fn sgr_underline_color() {
     let cells = t.grid.row_cells(0).unwrap();
     assert_eq!(cells[1].attrs.underline_color, Color::Default);
     // Underline itself should still be active
-    assert!(cells[1].attrs.underline);
+    assert!(cells[1].attrs.underline());
 }
 
 #[test]
@@ -581,37 +584,40 @@ fn sgr_individual_attribute_resets() {
     // SGR 22: reset bold and dim
     feed_bytes(&mut t, b"\x1b[22mA");
     let cells = t.grid.row_cells(0).unwrap();
-    assert!(!cells[0].attrs.bold, "bold should be reset by SGR 22");
-    assert!(!cells[0].attrs.dim, "dim should be reset by SGR 22");
-    assert!(cells[0].attrs.italic, "italic should remain after SGR 22");
+    assert!(!cells[0].attrs.bold(), "bold should be reset by SGR 22");
+    assert!(!cells[0].attrs.dim(), "dim should be reset by SGR 22");
+    assert!(cells[0].attrs.italic(), "italic should remain after SGR 22");
     assert!(
-        cells[0].attrs.underline,
+        cells[0].attrs.underline(),
         "underline should remain after SGR 22"
     );
 
     // SGR 23: reset italic
     feed_bytes(&mut t, b"\x1b[23mB");
     let cells = t.grid.row_cells(0).unwrap();
-    assert!(!cells[1].attrs.italic, "italic should be reset by SGR 23");
+    assert!(!cells[1].attrs.italic(), "italic should be reset by SGR 23");
 
     // SGR 24: reset underline
     feed_bytes(&mut t, b"\x1b[24mC");
     let cells = t.grid.row_cells(0).unwrap();
     assert!(
-        !cells[2].attrs.underline,
+        !cells[2].attrs.underline(),
         "underline should be reset by SGR 24"
     );
 
     // SGR 27: reset inverse
     feed_bytes(&mut t, b"\x1b[27mD");
     let cells = t.grid.row_cells(0).unwrap();
-    assert!(!cells[3].attrs.inverse, "inverse should be reset by SGR 27");
+    assert!(
+        !cells[3].attrs.inverse(),
+        "inverse should be reset by SGR 27"
+    );
 
     // SGR 29: reset strikethrough
     feed_bytes(&mut t, b"\x1b[29mE");
     let cells = t.grid.row_cells(0).unwrap();
     assert!(
-        !cells[4].attrs.strikethrough,
+        !cells[4].attrs.strikethrough(),
         "strikethrough should be reset by SGR 29"
     );
 }
@@ -623,22 +629,22 @@ fn sgr_double_underline_and_overline() {
     feed_bytes(&mut t, b"\x1b[4m"); // single underline
     feed_bytes(&mut t, b"\x1b[21mA");
     let cells = t.grid.row_cells(0).unwrap();
-    assert!(cells[0].attrs.double_underline);
+    assert!(cells[0].attrs.double_underline());
     assert!(
-        !cells[0].attrs.underline,
+        !cells[0].attrs.underline(),
         "single underline cleared by SGR 21"
     );
 
     // SGR 53: overline
     feed_bytes(&mut t, b"\x1b[53mB");
     let cells = t.grid.row_cells(0).unwrap();
-    assert!(cells[1].attrs.overline);
+    assert!(cells[1].attrs.overline());
 
     // SGR 55: reset overline
     feed_bytes(&mut t, b"\x1b[55mC");
     let cells = t.grid.row_cells(0).unwrap();
     assert!(
-        !cells[2].attrs.overline,
+        !cells[2].attrs.overline(),
         "overline should be reset by SGR 55"
     );
 }
@@ -883,25 +889,25 @@ fn sgr_blink_and_hidden() {
     // SGR 5: slow blink
     feed_bytes(&mut t, b"\x1b[5mA");
     let cells = t.grid.row_cells(0).unwrap();
-    assert!(cells[0].attrs.blink);
+    assert!(cells[0].attrs.blink());
 
     // SGR 6: rapid blink (treated same as slow blink)
     feed_bytes(&mut t, b"\x1b[6mB");
     let cells = t.grid.row_cells(0).unwrap();
-    assert!(cells[1].attrs.blink);
+    assert!(cells[1].attrs.blink());
 
     // SGR 25: reset blink
     feed_bytes(&mut t, b"\x1b[25mC");
     let cells = t.grid.row_cells(0).unwrap();
-    assert!(!cells[2].attrs.blink);
+    assert!(!cells[2].attrs.blink());
 
     // SGR 8: hidden
     feed_bytes(&mut t, b"\x1b[8mD");
     let cells = t.grid.row_cells(0).unwrap();
-    assert!(cells[3].attrs.hidden);
+    assert!(cells[3].attrs.hidden());
 
     // SGR 28: reset hidden
     feed_bytes(&mut t, b"\x1b[28mE");
     let cells = t.grid.row_cells(0).unwrap();
-    assert!(!cells[4].attrs.hidden);
+    assert!(!cells[4].attrs.hidden());
 }

--- a/crates/integration-tests/tests/parser_edge_cases.rs
+++ b/crates/integration-tests/tests/parser_edge_cases.rs
@@ -221,14 +221,14 @@ fn rapid_sgr_mode_cycling() {
     // Rapid cycling through SGR attributes
     feed_bytes(&mut t, b"\x1b[1mB\x1b[0m\x1b[3mI\x1b[0m\x1b[4mU\x1b[0mN");
     let cells = t.grid.row_cells(0).unwrap();
-    assert!(cells[0].attrs.bold);
-    assert!(!cells[0].attrs.italic);
-    assert!(cells[1].attrs.italic);
-    assert!(!cells[1].attrs.bold);
-    assert!(cells[2].attrs.underline);
-    assert!(!cells[3].attrs.bold);
-    assert!(!cells[3].attrs.italic);
-    assert!(!cells[3].attrs.underline);
+    assert!(cells[0].attrs.bold());
+    assert!(!cells[0].attrs.italic());
+    assert!(cells[1].attrs.italic());
+    assert!(!cells[1].attrs.bold());
+    assert!(cells[2].attrs.underline());
+    assert!(!cells[3].attrs.bold());
+    assert!(!cells[3].attrs.italic());
+    assert!(!cells[3].attrs.underline());
 }
 
 #[test]
@@ -237,9 +237,9 @@ fn multiple_sgr_in_one_sequence() {
     // SGR 1;3;4m = bold + italic + underline
     feed_bytes(&mut t, b"\x1b[1;3;4mX");
     let cells = t.grid.row_cells(0).unwrap();
-    assert!(cells[0].attrs.bold);
-    assert!(cells[0].attrs.italic);
-    assert!(cells[0].attrs.underline);
+    assert!(cells[0].attrs.bold());
+    assert!(cells[0].attrs.italic());
+    assert!(cells[0].attrs.underline());
 }
 
 #[test]

--- a/crates/integration-tests/tests/terminal_modes.rs
+++ b/crates/integration-tests/tests/terminal_modes.rs
@@ -342,8 +342,8 @@ fn cursor_save_restore_preserves_pen_attributes() {
     let cells = t.grid.row_cells(t.cursor.row).unwrap();
     // Find "Styled" text and check attributes
     let styled_start = t.cursor.col as usize - 6;
-    assert!(cells[styled_start].attrs.bold);
-    assert!(cells[styled_start].attrs.italic);
+    assert!(cells[styled_start].attrs.bold());
+    assert!(cells[styled_start].attrs.italic());
 }
 
 // ── CSI REP (repeat last char) ──────────────────────────────


### PR DESCRIPTION
## Summary

Replace 10 individual \`bool\` fields in \`Attrs\` struct with a single \`u16\` bitflags field, reducing Cell size from 28 bytes to 20 bytes.

### Measured Results

| Metric | Before | After | Change |
|---|---|---|---|
| \`sizeof(Attrs)\` | 22 bytes | **14 bytes** | -36% |
| \`sizeof(Cell)\` | 28 bytes | **20 bytes** | -29% |
| Cells per cache line | 2 | **3** | +50% |
| 80x24 grid | 52.5 KB | **37.5 KB** | -29% |
| 200x50 grid | 273.4 KB | **195.3 KB** | -29% |
| 300x80 grid | 656.2 KB | **468.8 KB** | -29% |

### Implementation

- 10 bit constants (\`ATTR_BOLD\`, \`ATTR_DIM\`, etc.) packed into \`flags: u16\`
- Accessor methods: \`bold()\`, \`set_bold()\` for read/write
- Builder methods: \`with_bold()\`, \`with_fg()\` for ergonomic construction
- Cell remains \`Copy\` + \`Default\` for \`slice::fill()\` SIMD optimization
- 6 spare bits in u16 for future attributes

### Files Changed (16)
- \`grid/mod.rs\`: Attrs struct + bitflag constants + accessors + builders
- \`state/actions.rs\`: SGR apply (\`set_bold(true)\` etc.)
- \`render_cpu/rasterize.rs\`: CPU attr reads (\`attrs.bold()\` etc.)
- \`render_gpu/cell_data.rs\`: GPU CellInstance packing
- 12 test files: struct literal → builder pattern

Closes #75

## Test plan
- [x] \`cargo clippy -D warnings\` passes (0 warnings)
- [x] \`cargo fmt --check\` passes
- [x] \`cargo test --workspace\` passes (893/893)
- [x] Cell size verified via \`std::mem::size_of\`: 20 bytes
- [ ] CI pipeline validates
- [ ] Jenkins Extended Validation passes