### PR TITLE
fix(app): implement synchronized output render gate and save/restore origin mode

### DIFF
--- a/crates/app/src/gui_runtime_app_handler.rs
+++ b/crates/app/src/gui_runtime_app_handler.rs
@@ -107,6 +107,12 @@ impl ApplicationHandler<GuiEvent> for GuiRuntimeApp {
             WindowEvent::CloseRequested => self.handle_close_requested(event_loop),
             WindowEvent::RedrawRequested => {
                 self.frame.redraw_in_flight = false;
+                // Synchronized output (mode 2026): defer rendering while BSU
+                // is active. The pending redraw will be serviced when the
+                // application sends ESU (CSI ? 2026 l) and queue_redraw fires.
+                if self.terminal.synchronized_output_enabled() {
+                    return;
+                }
                 if let Err(error) = self.draw_frame() {
                     self.fatal_error = Some(error);
                     event_loop.exit();

--- a/crates/core/src/state/actions.rs
+++ b/crates/core/src/state/actions.rs
@@ -393,7 +393,9 @@ impl TerminalState {
             scrollback: std::mem::replace(&mut self.scrollback, Scrollback::new(0)),
             saved_cursor: self.saved_cursor.take(),
             scroll_region: self.scroll_region.take(),
+            origin_mode: self.origin_mode,
         };
+        self.origin_mode = false;
 
         self.alternate_screen = Some(Box::new(saved));
     }
@@ -416,7 +418,9 @@ impl TerminalState {
             ),
             saved_cursor: self.saved_cursor.take(),
             scroll_region: self.scroll_region.take(),
+            origin_mode: self.origin_mode,
         };
+        self.origin_mode = false;
 
         self.alternate_screen = Some(Box::new(saved));
     }
@@ -429,6 +433,7 @@ impl TerminalState {
             self.scrollback = saved.scrollback;
             self.saved_cursor = saved.saved_cursor;
             self.scroll_region = saved.scroll_region;
+            self.origin_mode = saved.origin_mode;
             if !self.grid.is_empty() {
                 self.cursor.row = self.cursor.row.min(self.grid.height().saturating_sub(1));
                 self.cursor.col = self.cursor.col.min(self.grid.width().saturating_sub(1));

--- a/crates/core/src/state/mod.rs
+++ b/crates/core/src/state/mod.rs
@@ -52,6 +52,7 @@ pub(super) struct AlternateScreenState {
     pub(super) scrollback: Scrollback,
     pub(super) saved_cursor: Option<(Cursor, Attrs)>,
     pub(super) scroll_region: Option<(u16, u16)>,
+    pub(super) origin_mode: bool,
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
## Summary

Two functional gaps closed:

### 1. Synchronized Output Render Gate (HIGH impact)

Mode 2026 (BSU/ESU) was tracked in TerminalState but **never consulted by the renderer**. Apps sending CSI ?2026h (begin synchronized update) → bulk changes → CSI ?2026l (end) saw no effect - the renderer drew every frame independently, causing screen tearing.

**Fix**: `RedrawRequested` handler now checks `synchronized_output_enabled()`. When BSU is active, draw_frame is deferred. When ESU arrives via PTY output processing, `queue_redraw()` fires and all accumulated changes render in one frame.

**Impact**: neovim, helix, Claude Code TUI, and any app using the synchronized update protocol now renders without tearing.

### 2. Alt Screen Origin Mode Save/Restore (LOW impact)

`AlternateScreenState` was missing `origin_mode` field. DECOM state leaked between primary and alternate screens. Now saved on enter and restored on leave.

## Test plan
- [x] `cargo clippy -D warnings` (0 warnings)
- [x] `cargo fmt --check` passes
- [x] `cargo test --workspace` (939/939)
- [ ] CI pipeline validates
- [ ] Jenkins Extended Validation passes