### PR TITLE
chore(ci): bump ci-workflows SHA to b05016e

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
     name: rust-ci
     permissions:
       contents: read
-    uses: NDDev-it-com/ci-workflows/.github/workflows/rust-ci.yml@ca538d59aef41c1bb03c3669366c368128d5af88
+    uses: NDDev-it-com/ci-workflows/.github/workflows/rust-ci.yml@b05016e27151e2d5b3f07e1d856fff50f635ab15
     with:
       runner: ubuntu-24.04
       toolchain: "1.94.0"
@@ -94,7 +94,7 @@ jobs:
     name: supply-chain
     permissions:
       contents: read
-    uses: NDDev-it-com/ci-workflows/.github/workflows/rust-supply-chain.yml@ca538d59aef41c1bb03c3669366c368128d5af88
+    uses: NDDev-it-com/ci-workflows/.github/workflows/rust-supply-chain.yml@b05016e27151e2d5b3f07e1d856fff50f635ab15
     with:
       runner: ubuntu-24.04
       toolchain: "1.94.0"
@@ -112,7 +112,7 @@ jobs:
     name: Repo Lint
     permissions:
       contents: read
-    uses: NDDev-it-com/ci-workflows/.github/workflows/actionlint.yml@ca538d59aef41c1bb03c3669366c368128d5af88
+    uses: NDDev-it-com/ci-workflows/.github/workflows/actionlint.yml@b05016e27151e2d5b3f07e1d856fff50f635ab15
     with:
       runner: ubuntu-24.04
       actionlint_version: "1.7.11"

--- a/.github/workflows/fuzzing-batch.yml
+++ b/.github/workflows/fuzzing-batch.yml
@@ -22,7 +22,7 @@ jobs:
       actions: read
       contents: read
       security-events: write
-    uses: NDDev-it-com/ci-workflows/.github/workflows/clusterfuzzlite.yml@ca538d59aef41c1bb03c3669366c368128d5af88
+    uses: NDDev-it-com/ci-workflows/.github/workflows/clusterfuzzlite.yml@b05016e27151e2d5b3f07e1d856fff50f635ab15
     with:
       runner: ubuntu-24.04
       mode: batch

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -22,7 +22,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    uses: NDDev-it-com/ci-workflows/.github/workflows/pr-hygiene.yml@ca538d59aef41c1bb03c3669366c368128d5af88
+    uses: NDDev-it-com/ci-workflows/.github/workflows/pr-hygiene.yml@b05016e27151e2d5b3f07e1d856fff50f635ab15
     with:
       pr_title: false
       commitlint: false

--- a/.github/workflows/pr-hygiene.yml
+++ b/.github/workflows/pr-hygiene.yml
@@ -45,7 +45,7 @@ jobs:
     # workflow_dispatch the job is skipped; semantic-gate (which allows
     # skipped) reports the required "Semantic PR" context as success.
     if: ${{ github.event_name == 'pull_request' }}
-    uses: NDDev-it-com/ci-workflows/.github/workflows/pr-hygiene.yml@ca538d59aef41c1bb03c3669366c368128d5af88
+    uses: NDDev-it-com/ci-workflows/.github/workflows/pr-hygiene.yml@b05016e27151e2d5b3f07e1d856fff50f635ab15
     with:
       pr_title: true
       commitlint: false
@@ -78,7 +78,7 @@ jobs:
   stale:
     name: Stale
     if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
-    uses: NDDev-it-com/ci-workflows/.github/workflows/pr-hygiene.yml@ca538d59aef41c1bb03c3669366c368128d5af88
+    uses: NDDev-it-com/ci-workflows/.github/workflows/pr-hygiene.yml@b05016e27151e2d5b3f07e1d856fff50f635ab15
     with:
       pr_title: false
       commitlint: false

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -55,7 +55,7 @@ jobs:
       actions: read
       contents: read
       security-events: write
-    uses: NDDev-it-com/ci-workflows/.github/workflows/public-codeql.yml@ca538d59aef41c1bb03c3669366c368128d5af88
+    uses: NDDev-it-com/ci-workflows/.github/workflows/public-codeql.yml@b05016e27151e2d5b3f07e1d856fff50f635ab15
     with:
       runner: ubuntu-24.04
       languages: '["rust"]'
@@ -128,7 +128,7 @@ jobs:
       contents: read
       security-events: write
       id-token: write
-    uses: NDDev-it-com/ci-workflows/.github/workflows/public-scorecard.yml@ca538d59aef41c1bb03c3669366c368128d5af88
+    uses: NDDev-it-com/ci-workflows/.github/workflows/public-scorecard.yml@b05016e27151e2d5b3f07e1d856fff50f635ab15
     with:
       runner: ubuntu-24.04
       # Don't publish to the OpenSSF Scorecard API from PR/merge-group runs;
@@ -171,7 +171,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    uses: NDDev-it-com/ci-workflows/.github/workflows/public-dependency-review.yml@ca538d59aef41c1bb03c3669366c368128d5af88
+    uses: NDDev-it-com/ci-workflows/.github/workflows/public-dependency-review.yml@b05016e27151e2d5b3f07e1d856fff50f635ab15
     with:
       runner: ubuntu-24.04
       fail_on_severity: moderate
@@ -203,7 +203,7 @@ jobs:
       actions: read
       contents: read
       security-events: write
-    uses: NDDev-it-com/ci-workflows/.github/workflows/clusterfuzzlite.yml@ca538d59aef41c1bb03c3669366c368128d5af88
+    uses: NDDev-it-com/ci-workflows/.github/workflows/clusterfuzzlite.yml@b05016e27151e2d5b3f07e1d856fff50f635ab15
     with:
       runner: ubuntu-24.04
       mode: code-change


### PR DESCRIPTION
Bump ci-workflows SHA pin from `ca538d59aef41c1bb03c3669366c368128d5af88` to `b05016e27151e2d5b3f07e1d856fff50f635ab15`.